### PR TITLE
feat(rc-intl-core): support onError callback

### DIFF
--- a/packages/rc-intl-core/src/factory.ts
+++ b/packages/rc-intl-core/src/factory.ts
@@ -21,6 +21,7 @@ const createReactIntlFromInstance = (
       resetStore: instance.resetStore.bind(instance),
       setLocale: instance.setLocale.bind(instance),
       setMessages: instance.setMessages.bind(instance),
+      registerOnError: instance.registerOnError.bind(instance),
       getLocale: instance.getLocale.bind(instance),
       getMessages: instance.getMessages.bind(instance),
       message: instance.formatMessage.bind(instance),

--- a/packages/rc-intl-core/src/types/index.ts
+++ b/packages/rc-intl-core/src/types/index.ts
@@ -89,6 +89,7 @@ export type IWindIntlPublic = ReactIntl['formatMessage'] & {
   resetStore: ReactIntl['resetStore']
   setLocale: ReactIntl['setLocale']
   setMessages: ReactIntl['setMessages']
+  registerOnError: ReactIntl['registerOnError']
   getLocale: ReactIntl['getLocale']
   getMessages: ReactIntl['getMessages']
   message: ReactIntl['formatMessage']

--- a/packages/rc-intl/README.md
+++ b/packages/rc-intl/README.md
@@ -333,3 +333,34 @@ const Counter = ({ count }) => <span>{intl.number(count)}</span>
 
 export default Counter
 ```
+
+### intl.registerOnError
+
+注册发生错误时的回调函数。在回调函数中，你可以获取到一些有用的上下文信息。
+
+- 回调函数可以用于日志上报，从而你能及时发现线上的文案问题。
+- 回调函数可以返回 fallback 的文案，从而你可以利用上下文信息来返回更合理的异常文案。
+
+```ts
+intl.registerOnError(onError: OnError)
+
+type OnError = (errorInfo: {
+  code: ErrorCode
+  key?: string
+  ctx?: unknown
+  error?: any
+}) => string | void
+
+type ErrorCode =
+  | 'formatDate'
+  | 'formatNumber'
+  | 'formatMessage.messagesNotSetYet'
+  | 'formatMessage.notFound'
+  | 'formatMessage.invalidMessage'
+  | 'formatMessage.localeNotSet'
+  | 'formatMessage.formatError'
+
+```
+
+参考以下 demo：
+[$XView](https://xconsole.aliyun-inc.com/demo-playground?consoleOSId=console-components-intl-docs&entryKey=onError/index)

--- a/packages/rc-intl/demos/basic/index.demo.tsx
+++ b/packages/rc-intl/demos/basic/index.demo.tsx
@@ -1,10 +1,12 @@
 /**
-* @title basic
-*/
+ * @title basic
+ */
 
 import React from 'react'
 import { reactIntlFactory } from '@alicloud/console-components-intl'
 
+// 为了隔离各个demo之间的intl，这里我们使用工厂方法来创建独立的intl对象
+// 实际项目中一般直接 import intl 即可
 const intl = reactIntlFactory()
 
 export const messages = {
@@ -12,6 +14,12 @@ export const messages = {
   'text.normal.with.non.runtime': 'This is a normal text with non-runtime.',
   'text.normal.with.chinese': '这是一段优美的文字',
   'text.with.html': 'This is <span style="color: red">{text}</span> text.',
+  'text.with.format': `身份：{value, select,
+    actiontrail {ActionTrail 委派管理员}
+    config {CloudConfig 委派管理员}
+    yundun {云安全中心委派管理员}
+    cloudfw {CloudFirewall 委派管理员}
+    other {委派管理员}}`,
 }
 
 // 设置语言文案
@@ -29,6 +37,7 @@ const App: React.FC<{}> = () => {
       <p>{intl('text.normal')}</p>
       <p>{normalTextWithNonRuntime}</p>
       <p>{intl('text.normal.with.chinese')}</p>
+      <p>{intl('text.with.format', { value: 'yundun' })}</p>
       <p>intl.html将包含html标签的文案渲染输出。注意防范XSS攻击。</p>
       <p>{intl.html('text.with.html', { text: 'my html' })}</p>
     </div>

--- a/packages/rc-intl/demos/onError/index.demo.tsx
+++ b/packages/rc-intl/demos/onError/index.demo.tsx
@@ -1,0 +1,58 @@
+/**
+ * @title onError
+ */
+
+import React from 'react'
+import { reactIntlFactory } from '@alicloud/console-components-intl'
+
+const intl = reactIntlFactory()
+
+export const messages = {
+  'text.with.format': `身份：{value, select,
+    actiontrail {ActionTrail 委派管理员}
+    config {CloudConfig 委派管理员}
+    yundun {云安全中心委派管理员}
+    cloudfw {CloudFirewall 委派管理员}
+    other {委派管理员}}`,
+}
+
+// 设置语言文案
+intl.set({
+  messages,
+  locale: 'en-US',
+})
+
+// 可以注册多个onError回调，它们都会被调用
+intl.registerOnError((info) => {
+  console.log('get intl error1:', info)
+  // onError可以返回fallback的文案
+  // 如果多个onError都返回了fallback文案，则先注册的onError优先
+  // 这一行的默认会优先与下一个onError的默认文案：
+  // return 'unknown!'
+})
+
+intl.registerOnError((info) => {
+  // 可以上报日志
+  console.log('get intl error2:', info)
+  // onError可以返回fallback的文案
+  const ctx = info.ctx as any
+  const value = ctx.values?.value || ctx.values?.state
+  // 如果在values对象中有一些关键的属性，则可以用这些属性作为fallback
+  if (typeof value === 'string') return value
+  if (info.key) return `unknown message: ${info.key}`
+})
+
+const App: React.FC<{}> = () => {
+  return (
+    <div style={{ marginLeft: '16px' }}>
+      <p>发生错误时会调用onError回调，并从它获取默认文案：</p>
+      <p>{intl('unknown.key')}</p>
+      <p>你可以在onError回调中，利用上下文信息返回更有用的文案：</p>
+      <p>{intl('unknown.key', { state: 'running' })}</p>
+      <p>你可以在onError回调中，利用上下文信息返回更有用的文案：</p>
+      <p>{intl('text.with.format。typo', { value: 'yundun' })}</p>
+    </div>
+  )
+}
+
+export default intl.withProvider()(App)

--- a/packages/rc-intl/src/factory.tsx
+++ b/packages/rc-intl/src/factory.tsx
@@ -21,6 +21,7 @@ const createReactIntlFromInstance = (
       resetStore: instance.resetStore.bind(instance),
       setLocale: instance.setLocale.bind(instance),
       setMessages: instance.setMessages.bind(instance),
+      registerOnError: instance.registerOnError.bind(instance),
       getLocale: instance.getLocale.bind(instance),
       getMessages: instance.getMessages.bind(instance),
       message: instance.formatMessage.bind(instance),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,7 +140,7 @@ importers:
       '@alicloud/console-components-console-menu': ^1.2.4
       '@alicloud/console-components-page': ^1.0.14
       '@alicloud/console-components-table': ^1.0.17
-      '@alicloud/css-var-utils': 'workspace:^0.1.0'
+      '@alicloud/css-var-utils': ^0.1.0
       '@babel/runtime': ^7.4.3
       classnames: ^2.2.5
   packages/rc-confirm:
@@ -279,7 +279,7 @@ importers:
       react-responsive: 5.0.0
       recompose: 0.27.1
     devDependencies:
-      '@alicloud/console-components-app-layout': 1.0.10
+      '@alicloud/console-components-app-layout': 'link:../rc-app-layout'
       '@alicloud/console-components-page': 'link:../rc-page'
     specifiers:
       '@alicloud/console-components-app-layout': ^1.0.10


### PR DESCRIPTION
预发文档：
https://xconsole.aliyun-inc.com/demo-playground?consoleOSId=console-components-intl-docs&servePath=https%3A%2F%2Fopensource-microapp.oss-cn-hangzhou.aliyuncs.com%2Fapp%2Fbreezr-docs%2Fconsole-components-intl-docs%2F-pre%2F&entryKey=README#intlregisteronerror