### PR TITLE
fix(rc-console-menu): RoutableMenu应该默认展开初始页面对应的菜单项，即使它不在defaultOpenKeys中

### DIFF
--- a/packages/fake-browser/src/FakeBrowser.tsx
+++ b/packages/fake-browser/src/FakeBrowser.tsx
@@ -6,7 +6,7 @@ import styled from 'styled-components'
 const LIGHT_GRAY = 'hsl(0, 0%, 32%)'
 const GRAY = 'hsl(0, 0%, 78%)'
 
-const LeftArrowIcon: React.FC<React.SVGProps<SVGSVGElement>> = props => (
+const LeftArrowIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
   <svg
     {...props}
     fill="currentColor"
@@ -17,7 +17,7 @@ const LeftArrowIcon: React.FC<React.SVGProps<SVGSVGElement>> = props => (
   </svg>
 )
 
-const RightArrowIcon: React.FC<React.SVGProps<SVGSVGElement>> = props => (
+const RightArrowIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
   <svg
     {...props}
     fill="currentColor"
@@ -64,11 +64,18 @@ const getUserConfirmation = (
 
 const createPath = (location: Location) => location.pathname + location.search
 
-const FakeBrowser: React.FC<{}> = ({ children, ...props }) => {
+const FakeBrowser: React.FC<{ memoryRouterProps?: any }> = ({
+  children,
+  memoryRouterProps,
+  ...props
+}) => {
   const [url, setUrl] = useState<null | string>(null)
 
   return (
-    <MemoryRouter getUserConfirmation={getUserConfirmation}>
+    <MemoryRouter
+      getUserConfirmation={getUserConfirmation}
+      {...memoryRouterProps}
+    >
       <Route
         render={({ history, location }) => (
           <div
@@ -147,10 +154,10 @@ const FakeBrowser: React.FC<{}> = ({ children, ...props }) => {
                   }}
                   type="text"
                   value={url || createPath(location)}
-                  onChange={e => {
+                  onChange={(e) => {
                     setUrl(e.target.value)
                   }}
-                  onKeyDown={e => {
+                  onKeyDown={(e) => {
                     if (e.key === 'Enter') {
                       setUrl(null)
                       history.push((e.target as HTMLInputElement).value)

--- a/packages/fake-browser/src/WithWrapper.tsx
+++ b/packages/fake-browser/src/WithWrapper.tsx
@@ -4,7 +4,8 @@ import FakeBrowser from './FakeBrowser'
 
 const FakeBrowserWithWrapper: React.FC<{
   rndProps?: RndProps
-}> = ({ children, rndProps }) => (
+  memoryRouterProps?: any
+}> = ({ children, rndProps, memoryRouterProps }) => (
   <Rnd
     disableDragging
     {...rndProps}
@@ -35,7 +36,7 @@ const FakeBrowserWithWrapper: React.FC<{
       ...(rndProps && rndProps.style),
     }}
   >
-    <FakeBrowser>{children}</FakeBrowser>
+    <FakeBrowser memoryRouterProps={memoryRouterProps}>{children}</FakeBrowser>
   </Rnd>
 )
 

--- a/packages/rc-console-menu/demos/routable-menu-default-open-2.demo.tsx
+++ b/packages/rc-console-menu/demos/routable-menu-default-open-2.demo.tsx
@@ -1,0 +1,50 @@
+import React from 'react'
+import RoutableMenu from '@alicloud/console-components-console-menu/RoutableMenu'
+import { IRoutableItemDescriptor } from '@alicloud/console-components-console-menu'
+import { FakeBrowserWithWrapper as FakeBrowser } from '@alicloud/console-components-fake-browser'
+
+const items: IRoutableItemDescriptor[] = [
+  { key: '/home', to: '/', label: '首页' },
+  { key: '/instance', to: '/instance', label: '实例概览' },
+
+  // Defination as a sub menu
+  {
+    key: '/logs',
+    label: '日志',
+    items: [
+      { key: '/pre', to: '/pre', label: '预发环境' },
+      { key: '/prod', to: '/prod', label: '生产环境' },
+    ],
+  },
+  {
+    key: '/rd',
+    label: '资源目录',
+    items: [
+      { key: '/rd-overview', to: '/rd-overview', label: '概览' },
+      { key: '/rd-members', to: '/rd-members', label: '成员列表' },
+    ],
+  },
+]
+
+// 初始打开某个页面，应该默认展开这个页面的父节点，即使defaultOpenKeys不包含它的父节点
+const Example = () => {
+  return (
+    <FakeBrowser
+      memoryRouterProps={{
+        initialEntries: ['/rd-overview'],
+        // initialEntries: ['/home'],
+        initialIndex: 0,
+      }}
+    >
+      <div>
+        <RoutableMenu
+          defaultOpenKeys={['/logs']}
+          header="阿里云控制台"
+          items={items}
+        />
+      </div>
+    </FakeBrowser>
+  )
+}
+
+export default Example

--- a/packages/rc-console-menu/src/utils.tsx
+++ b/packages/rc-console-menu/src/utils.tsx
@@ -20,7 +20,7 @@ export function GetFusionConfig<PropType extends { fusionConfig: any }>(
   Wrapped: React.ComponentType<PropType>
 ) {
   const ConfifgConsumer: any = (ConfigProvider as any).Consumer
-  const HOC: React.FC<Omit<PropType, 'fusionConfig'>> = props => (
+  const HOC: React.FC<Omit<PropType, 'fusionConfig'>> = (props) => (
     <ConfifgConsumer>
       {(context: any) => (
         <Wrapped {...(props as PropType)} fusionConfig={context} />
@@ -28,4 +28,14 @@ export function GetFusionConfig<PropType extends { fusionConfig: any }>(
     </ConfifgConsumer>
   )
   return HOC
+}
+
+export function dedup<T>(arr: T[]) {
+  return Array.from(new Set(arr))
+}
+
+export function ensureArray(value: any) {
+  if (Array.isArray(value)) return value
+  if (value === undefined) return []
+  return [value]
 }


### PR DESCRIPTION
简化了计算openKeys和defaultOpenKeys的逻辑，不再为openKeys维护一个额外状态（也不再需要计算actualOpenKeys），而是只计算一个新的defaultOpenKeys。
并且修复了“打开页面时，默认没有展开页面对应的菜单项”的问题。（routable-menu-default-open-2为复现demo，之前的代码表现不合理）

